### PR TITLE
add support for sale amount and order quantity fields

### DIFF
--- a/component.json
+++ b/component.json
@@ -7,7 +7,10 @@
   "main": "lib/index.js",
   "dependencies": {
     "component/each": "0.0.1",
-    "segmentio/analytics.js-integration": "^1.0.1"
+    "ndhoule/defaults":"1.0.1",
+    "ndhoule/foldl":"1.0.3",
+    "segmentio/analytics.js-integration": "^1.0.1",
+    "segmentio/obj-case": "^0.2.1"
   },
   "development": {
     "segmentio/analytics.js": "*",

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,8 +3,11 @@
  * Module dependencies.
  */
 
-var each = require('each');
 var integration = require('analytics.js-integration');
+var defaults = require('defaults');
+var foldl = require('foldl');
+var each = require('each');
+var get = require('obj-case');
 
 /**
  * Expose `TwitterAds`.
@@ -12,7 +15,7 @@ var integration = require('analytics.js-integration');
 
 var TwitterAds = module.exports = integration('Twitter Ads')
   .option('page', '')
-  .tag('<img src="//analytics.twitter.com/i/adsct?txn_id={{ pixelId }}&p_id=Twitter"/>')
+  .tag('<img src="//analytics.twitter.com/i/adsct?txn_id={{ pixelId }}&p_id=Twitter&tw_sale_amount={{ revenue }}&tw_order_quantity={{ quantity }}"/>')
   .mapping('events');
 
 /**
@@ -25,6 +28,11 @@ TwitterAds.prototype.initialize = function() {
   this.ready();
 };
 
+var defaultQueryValues = {
+  revenue: 0,
+  quantity: 0
+};
+
 /**
  * Page.
  *
@@ -34,7 +42,7 @@ TwitterAds.prototype.initialize = function() {
 
 TwitterAds.prototype.page = function() {
   if (this.options.page) {
-    this.load({ pixelId: this.options.page });
+    this.load(defaults({ pixelId: this.options.page }, defaultQueryValues));
   }
 };
 
@@ -49,6 +57,34 @@ TwitterAds.prototype.track = function(track) {
   var events = this.events(track.event());
   var self = this;
   each(events, function(pixelId) {
-    self.load({ pixelId: pixelId });
+    self.load(defaults({
+      pixelId: pixelId,
+      quantity: track.proxy('properties.quantity'),
+      revenue: track.revenue()
+    }, defaultQueryValues));
+  });
+};
+
+/**
+ * Completed Order.
+ *
+ * @api public
+ * @param {Track} track
+ */
+
+TwitterAds.prototype.completedOrder = function(track) {
+  var events = this.events(track.event());
+  // add up all the quantities of each product
+  var quantity = foldl(function(cartQuantity, product) {
+    return cartQuantity + (get(product, 'quantity') || 0);
+  }, 0, track.products());
+
+  var self = this;
+  each(events, function(pixelId) {
+    self.load(defaults({
+      pixelId: pixelId,
+      quantity: quantity,
+      revenue: track.revenue()
+    }, defaultQueryValues));
   });
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -12,7 +12,8 @@ describe('Twitter Ads', function() {
     events: {
       signup: 'c36462a3',
       login: '6137ab24',
-      play: 'e3196de1'
+      play: 'e3196de1',
+      'Completed Order': 'adsf7as8'
     }
   };
 
@@ -57,7 +58,7 @@ describe('Twitter Ads', function() {
       it('should send if `page` option is defined', function() {
         twitter.options.page = 'e3196de1';
         analytics.page();
-        analytics.loaded('<img src="http://analytics.twitter.com/i/adsct?txn_id=e3196de1&p_id=Twitter">');
+        analytics.loaded('<img src="http://analytics.twitter.com/i/adsct?txn_id=e3196de1&p_id=Twitter&tw_sale_amount=0&tw_order_quantity=0">');
       });
     });
 
@@ -73,13 +74,51 @@ describe('Twitter Ads', function() {
 
       it('should send correctly', function() {
         analytics.track('play');
-        analytics.loaded('<img src="http://analytics.twitter.com/i/adsct?txn_id=e3196de1&p_id=Twitter">');
+        analytics.loaded('<img src="http://analytics.twitter.com/i/adsct?txn_id=e3196de1&p_id=Twitter&tw_sale_amount=0&tw_order_quantity=0">');
       });
 
       it('should support array events', function() {
         twitter.options.events = [{ key: 'event', value: 12 }];
         analytics.track('event');
-        analytics.loaded('<img src="http://analytics.twitter.com/i/adsct?txn_id=12&p_id=Twitter">');
+        analytics.loaded('<img src="http://analytics.twitter.com/i/adsct?txn_id=12&p_id=Twitter&tw_sale_amount=0&tw_order_quantity=0">');
+      });
+
+      it('should send revenue', function() {
+        analytics.track('signup', { revenue: 10 });
+        analytics.loaded('<img src="http://analytics.twitter.com/i/adsct?txn_id=c36462a3&p_id=Twitter&tw_sale_amount=10&tw_order_quantity=0">');
+      });
+
+      it('should send total as revenue and quantity of all products with completed order', function() {
+        analytics.track('Completed Order', {
+          orderId: '50314b8e9bcf000000000000',
+          total: 30,
+          revenue: 25,
+          shipping: 3,
+          tax: 2,
+          discount: 2.5,
+          coupon: 'hasbros',
+          currency: 'USD',
+          repeat: true,
+          products: [
+            {
+              id: '507f1f77bcf86cd799439011',
+              sku: '45790-32',
+              name: 'Monopoly: 3rd Edition',
+              price: 19,
+              quantity: 1,
+              category: 'Games'
+            },
+            {
+              id: '505bd76785ebb509fc183733',
+              sku: '46493-32',
+              name: 'Uno Card Game',
+              price: 3,
+              quantity: 2,
+              category: 'Games'
+            }
+          ]
+        });
+        analytics.loaded('<img src="http://analytics.twitter.com/i/adsct?txn_id=adsf7as8&p_id=Twitter&tw_sale_amount=25&tw_order_quantity=3">');
       });
     });
   });


### PR DESCRIPTION
Twitter has multiple pixel "types", but they all have the exact same querystring signature.  They've added 2 fields to the qs, `sale_amount` and `order_quantity`. The default 'zero value' for each field is  `0`. Otherwise:

> "when either or both of these values are received, you will be able to see them alongside your conversions."

A few complications:
- The default return value for facade's `track.quantity()` is `1`, so we can't use that getter directly in attempting to populate the field. Further, that field is not specced at the top level on `any` event, so I'm thinking for generic `track` events we just [check for it directly](https://github.com/segment-integrations/analytics.js-integration-twitter-ads/compare/add/order-data?expand=1#diff-6d186b954a58d5bb740f73d84fe39073R62)
- For `Completed Order` events (when mapped), I'm not sure what the best means of reporting "top level" purchase quantity without breaking out by item. Here's the language they use:

> The tracking code snippet can also be used to gain an understanding of the ROI of your Promoted Tweets campaigns, including total revenue (or total conversion value) your campaign generated, and \* **total number of items purchased** *.

My current "best guess" is to [sum the quantities of each item](https://github.com/segment-integrations/analytics.js-integration-twitter-ads/compare/add/order-data?expand=1#diff-6d186b954a58d5bb740f73d84fe39073R79). Hoping to get in touch with a member of their team to discern best practice there.

@ndhoule 
