### PR TITLE
add support for mapping conversion pixels to specific pages by path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,8 @@ var integration = require('analytics.js-integration');
 var TwitterAds = module.exports = integration('Twitter Ads')
   .option('page', '')
   .tag('<img src="//analytics.twitter.com/i/adsct?txn_id={{ pixelId }}&p_id=Twitter"/>')
-  .mapping('events');
+  .mapping('events')
+  .mapping('paths');
 
 /**
  * Initialize.
@@ -32,7 +33,16 @@ TwitterAds.prototype.initialize = function() {
  * @param {Page} page
  */
 
-TwitterAds.prototype.page = function() {
+TwitterAds.prototype.page = function(page) {
+  var paths = this.paths(page.path());
+  var self = this;
+
+  // send explicitly mapped pixel(s), if any.
+  each(paths, function(pixelId) {
+    self.load({ pixelId: pixelId });
+  });
+
+  // send generic "pageview" pixel, if configured.
   if (this.options.page) {
     this.load({ pixelId: this.options.page });
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -11,8 +11,12 @@ describe('Twitter Ads', function() {
   var options = {
     events: {
       signup: 'c36462a3',
-      login: '6137ab24',
+      login: 'c36462a3',
       play: 'e3196de1'
+    },
+    paths: {
+      '/pricing': 'c36462a4',
+      '/features': 'c36462a5'
     }
   };
 
@@ -54,8 +58,20 @@ describe('Twitter Ads', function() {
         analytics.didNotCall(twitter.load);
       });
 
+      it('should not send if location.pathname does not match any mapped paths', function() {
+        twitter.options.paths = { '/test/something': 'e3196de1' };
+        analytics.page();
+        analytics.didNotCall(twitter.load);
+      });
+
       it('should send if `page` option is defined', function() {
         twitter.options.page = 'e3196de1';
+        analytics.page();
+        analytics.loaded('<img src="http://analytics.twitter.com/i/adsct?txn_id=e3196de1&p_id=Twitter">');
+      });
+
+      it('should send if location.pathname matches mapped path', function() {
+        twitter.options.paths = { '/test/': 'e3196de1' };
         analytics.page();
         analytics.loaded('<img src="http://analytics.twitter.com/i/adsct?txn_id=e3196de1&p_id=Twitter">');
       });


### PR DESCRIPTION
since twitter ads _only_ allows configuring conversions on the basis of pixels loading and they don't have a generic pageview function like facebook, I think this will enable our customers to get a lot more granular in tracking _specfic_ pages for conversions without incurring redundant `track` calls for "Viewed XXX Page" when they're already calling `.page()`

for context, this was prompted by thoughts related to this ticket: https://segment.zendesk.com/agent/tickets/32217

thoughts?!

@ndhoule @f2prateek  

obvious **Do Not Merge** until metadata is updated.
