### PR TITLE
update ecommerce spec syntax to v2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -67,13 +67,13 @@ TwitterAds.prototype.track = function(track) {
 };
 
 /**
- * Completed Order.
+ * Order Completed.
  *
  * @api public
  * @param {Track} track
  */
 
-TwitterAds.prototype.completedOrder = function(track) {
+TwitterAds.prototype.orderCompleted = function(track) {
   var events = this.events(track.event());
   // add up all the quantities of each product
   var quantity = foldl(function(cartQuantity, product) {

--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
   "dependencies": {
     "@ndhoule/defaults": "^2.0.1",
     "@ndhoule/foldl": "^2.0.1",
-    "@segment/analytics.js-integration": "^2.1.0",
+    "@segment/analytics.js-integration": "^3.1.0",
     "component-each": "^0.2.6",
     "obj-case": "^0.2.0"
   },
   "devDependencies": {
     "@segment/analytics.js-core": "^3.0.0",
-    "@segment/analytics.js-integration-tester": "^2.0.0",
+    "@segment/analytics.js-integration-tester": "^3.0.0",
     "@segment/clear-env": "^2.0.0",
     "@segment/eslint-config": "^3.1.1",
     "browserify": "^13.0.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -14,7 +14,7 @@ describe('Twitter Ads', function() {
       signup: 'c36462a3',
       login: '6137ab24',
       play: 'e3196de1',
-      'Completed Order': 'adsf7as8'
+      'Order Completed': 'adsf7as8'
     }
   };
 
@@ -89,8 +89,8 @@ describe('Twitter Ads', function() {
         analytics.loaded('<img src="http://analytics.twitter.com/i/adsct?txn_id=c36462a3&p_id=Twitter&tw_sale_amount=10&tw_order_quantity=0">');
       });
 
-      it('should send total as revenue and quantity of all products with completed order', function() {
-        analytics.track('Completed Order', {
+      it('should send total as revenue and quantity of all products with Order Completed', function() {
+        analytics.track('Order Completed', {
           orderId: '50314b8e9bcf000000000000',
           total: 30,
           revenue: 25,


### PR DESCRIPTION
This PR changes the ecommerce V1 syntax Action + Object to the new V2 syntax, Object + Action.

This PR will be waiting on a few blockers, a refactor of the Analytics-Events repo to be more concise and readable as we add more events to our spec and for similar changes to be made to all other integrations currently using V1 syntax.

Tests are failing because it isn't properly aliasing against the new spec'd events. These tests will need to pass, dependent on a new version of Analytics Events and Analytics.js-Private before being merged.
