### PR TITLE
support universal website tag

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,9 @@ var get = require('obj-case');
 
 var TwitterAds = module.exports = integration('Twitter Ads')
   .option('page', '')
-  .tag('<img src="//analytics.twitter.com/i/adsct?txn_id={{ pixelId }}&p_id=Twitter&tw_sale_amount={{ revenue }}&tw_order_quantity={{ quantity }}"/>')
+  .option('universalTagPixelId', '')
+  .tag('singleTag', '<img src="//analytics.twitter.com/i/adsct?txn_id={{ pixelId }}&p_id=Twitter&tw_sale_amount={{ revenue }}&tw_order_quantity={{ quantity }}"/>')
+  .tag('universalTag', '<script src="//static.ads-twitter.com/uwt.js">')
   .mapping('events');
 
 /**
@@ -26,7 +28,21 @@ var TwitterAds = module.exports = integration('Twitter Ads')
  */
 
 TwitterAds.prototype.initialize = function() {
-  this.ready();
+  var self = this;
+
+  // load universal website tag
+  if (this.options.universalTagPixelId) {
+    /* eslint-disable */
+    (function(e,n,u,a){e.twq||(a=e.twq=function(){a.exe?a.exe.apply(a,arguments):a.queue.push(arguments);},a.version='1',a.queue=[])})(window,document,'script');
+    /* eslint-disable */
+
+    this.load('universalTag', function() {
+      window.twq('init', self.options.universalTagPixelId);
+      self.ready();
+    });
+  } else {
+    this.ready();
+  }
 };
 
 var defaultQueryValues = {
@@ -42,8 +58,10 @@ var defaultQueryValues = {
  */
 
 TwitterAds.prototype.page = function() {
-  if (this.options.page) {
-    this.load(defaults({ pixelId: this.options.page }, defaultQueryValues));
+  if (this.options.universalTagPixelId) {
+    window.twq('track', 'PageView');
+  } else if (this.options.page) {
+    this.load('singleTag', defaults({ pixelId: this.options.page }, defaultQueryValues));
   }
 };
 
@@ -58,7 +76,7 @@ TwitterAds.prototype.track = function(track) {
   var events = this.events(track.event());
   var self = this;
   each(events, function(pixelId) {
-    self.load(defaults({
+    self.load('singleTag', defaults({
       pixelId: pixelId,
       quantity: track.proxy('properties.quantity'),
       revenue: track.revenue()
@@ -82,7 +100,7 @@ TwitterAds.prototype.orderCompleted = function(track) {
 
   var self = this;
   each(events, function(pixelId) {
-    self.load(defaults({
+    self.load('singleTag', defaults({
       pixelId: pixelId,
       quantity: quantity,
       revenue: track.revenue()

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -66,6 +66,21 @@ describe('Twitter Ads', function() {
     });
   });
 
+  describe('during loading', function() {
+    describe('initialize', function() {
+      beforeEach(function(done) {
+        twitter.options.universalTagPixelId = 'teemo';
+        analytics.initialize();
+        analytics.stub(window, 'twq');
+        analytics.once('ready', done);
+      });
+
+      it('should initialize twq with the universal tag pixel id if provided', function() {
+        analytics.called(window.twq, 'init', 'teemo');
+      }); 
+    }); 
+  });
+
   describe('after loading', function() {
     beforeEach(function(done) {
       analytics.once('ready', done);


### PR DESCRIPTION
This adds support for Twitter's [Universal Website Tag](https://business.twitter.com/en/help/campaign-measurement-and-analytics/conversion-tracking-for-websites.html)

I'm leaving in support for their single event tags since removing it would be breaking change. I also think that using both in conjunction can be useful since the universal website tag conversion logic is solely limited to URL matching where as the single event tag can be based on mapped Segment events, allowing you to use whatever custom logic code you might have for conversions.

No matter how many different conversion events you make inside Twitter via UWT, the script doesn't change. So there is no need to for `.track()` calls. I believe all the magic just happens through twitter's script
- [ ] docs
- [ ] update metadata
- [ ] test on staging
  @wcjohnson11 @sperand-io @tsholmes 
